### PR TITLE
Add benchmarks for [rust] cilk_scope and rayon::spawn

### DIFF
--- a/rust/benches/fib.rs
+++ b/rust/benches/fib.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, PlotConfiguration};
-use bench_lib::fib::{cilk_fib, cilk_scope_fib, rayon_fib};
+use bench_lib::fib::{cilk_fib, cilk_scope_fib, rayon_fib, rayon_spawn_fib};
 
 fn bench_fibs(c: &mut Criterion) {
     // Use a log scale because the asmyptomotic complexity is exponential.
@@ -15,6 +15,9 @@ fn bench_fibs(c: &mut Criterion) {
         });
         group.bench_with_input(BenchmarkId::new("Rayon", i), i, |b, i| {
             b.iter(|| rayon_fib(black_box(*i)));
+        });
+        group.bench_with_input(BenchmarkId::new("Rayon-Spawn", i), i, |b, i| {
+            b.iter(|| rayon_spawn_fib(black_box(*i)));
         });
     }
     group.finish();

--- a/rust/benches/fib.rs
+++ b/rust/benches/fib.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, PlotConfiguration};
-use bench_lib::fib::{cilk_fib, rayon_fib};
+use bench_lib::fib::{cilk_fib, cilk_scope_fib, rayon_fib};
 
 fn bench_fibs(c: &mut Criterion) {
     // Use a log scale because the asmyptomotic complexity is exponential.
@@ -9,6 +9,9 @@ fn bench_fibs(c: &mut Criterion) {
     for i in [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 30, 35, 40].iter() {
         group.bench_with_input(BenchmarkId::new("Rust-Cilk", i), i, |b, i| {
             b.iter(|| cilk_fib(black_box(*i)));
+        });
+        group.bench_with_input(BenchmarkId::new("Rust-Cilk-Scope", i), i, |b, i| {
+            b.iter(|| cilk_scope_fib(black_box(*i)));
         });
         group.bench_with_input(BenchmarkId::new("Rayon", i), i, |b, i| {
             b.iter(|| rayon_fib(black_box(*i)));

--- a/rust/src/bin/fib.rs
+++ b/rust/src/bin/fib.rs
@@ -8,6 +8,8 @@ enum WhichFib {
     Rayon,
     /// Use Cilk with cilk_scope for the Fibonacci computation.
     CilkWithScope,
+    /// Use Rayon with rayon::scope and rayon::spawn for the Fibonacci computation.
+    RayonWithSpawn,
 }
 
 #[derive(Parser)]
@@ -27,6 +29,7 @@ fn run(num_runs: u32, n: u8, which: WhichFib) -> usize {
         WhichFib::Cilk => bench_lib::fib::cilk_fib,
         WhichFib::Rayon => bench_lib::fib::rayon_fib,
         WhichFib::CilkWithScope => bench_lib::fib::cilk_scope_fib,
+        WhichFib::RayonWithSpawn => bench_lib::fib::rayon_spawn_fib,
     };
     let n = n as usize;
     for _ in 0..num_runs {

--- a/rust/src/bin/fib.rs
+++ b/rust/src/bin/fib.rs
@@ -6,6 +6,8 @@ enum WhichFib {
     Cilk,
     /// Use Rayon for the Fibonacci computation.
     Rayon,
+    /// Use Cilk with cilk_scope for the Fibonacci computation.
+    CilkWithScope,
 }
 
 #[derive(Parser)]
@@ -24,6 +26,7 @@ fn run(num_runs: u32, n: u8, which: WhichFib) -> usize {
     let fib: fn(usize) -> usize = match which {
         WhichFib::Cilk => bench_lib::fib::cilk_fib,
         WhichFib::Rayon => bench_lib::fib::rayon_fib,
+        WhichFib::CilkWithScope => bench_lib::fib::cilk_scope_fib,
     };
     let n = n as usize;
     for _ in 0..num_runs {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -17,6 +17,19 @@ pub mod fib {
         }
     }
 
+    pub fn cilk_scope_fib(n: usize) -> usize {
+        match n {
+            0 | 1 => n,
+            2..=SERIAL_CUTOFF => cilk_scope_fib(n - 1) + cilk_scope_fib(n - 2),
+            _ => cilk_scope {
+                    let x = cilk_spawn { cilk_scope_fib(n - 1) };
+                    let y = cilk_scope_fib(n - 2);
+                    cilk_sync;
+                    x + y
+                }
+        }
+    }
+
     pub fn rayon_fib(n: usize) -> usize {
         match n {
             0 | 1 => n,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -40,4 +40,19 @@ pub mod fib {
             }
         }
     }
+
+    pub fn rayon_spawn_fib(n: usize) -> usize {
+        match n {
+            0 | 1 => n,
+            2..=SERIAL_CUTOFF => rayon_spawn_fib(n - 1) + rayon_spawn_fib(n - 2),
+            _ => {
+                let mut x: Option<usize> = None;
+                let y = rayon::scope(|s| {
+                    s.spawn(|_| x = Some(rayon_spawn_fib(n - 1)));
+                    rayon_spawn_fib(n - 2)
+                });
+                x.expect("closure should've completed!") + y
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a benchmark for Rust + Cilk that uses the new cilk_scope keyword as well as a benchmark for rayon that uses rayon::scope and rayon::spawn.